### PR TITLE
Prevent error when secrets directory not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,14 +6,16 @@ const path = require('path');
 const SECRETS_DIR = '/run/secrets';
 const output = {};
 
-const files = fs.readdirSync(SECRETS_DIR);
+if (fs.existsSync(SECRETS_DIR)) {
+  const files = fs.readdirSync(SECRETS_DIR);
 
-files.forEach(function(file, index) {
-  const fullPath = path.join(SECRETS_DIR, file);
-  const key = file;
-  const data = fs.readFileSync(fullPath, 'utf8').toString().trim();
+  files.forEach(function(file, index) {
+    const fullPath = path.join(SECRETS_DIR, file);
+    const key = file;
+    const data = fs.readFileSync(fullPath, 'utf8').toString().trim();
 
-  output[key] = data;
-});
+    output[key] = data;
+  });
+}
 
 module.exports = output;


### PR DESCRIPTION
When doing local development, I'm (currently) just using Docker Compose. So, the secrets directory doesn't exist, which causes this module to blow up.  

If no secrets are found, this PR simply returns an empty object, which at least prevents the code from exploding.