### PR TITLE
Allow overriding of directory using SECRETS_DIR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ npm install @cloudreach/docker-secrets
 const secrets = require('@cloudreach/docker-secrets');
 console.log(secrets);
 ```
+
+## Customization
+
+If the `SECRETS_DIR` environment variable is set, the specified location will be used in stead of `/run/secrets`.
+

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const fs   = require('fs');
 const path = require('path');
 
-const SECRETS_DIR = '/run/secrets';
+const SECRETS_DIR = process.env.SECRETS_DIR || '/run/secrets';
 const output = {};
 
 if (fs.existsSync(SECRETS_DIR)) {


### PR DESCRIPTION
I've been doing some experimenting with changing mount points for secrets and also have another use case where, in another orchestration engine, I'm putting the secrets in other places. Would be nice to use the same library and not introduce code changes/branches, but simply swap secret locations using environment variables. This allow that. Oh... and Merry Christmas! 🎄😄 